### PR TITLE
Increase GitIQ logo dimensions by 50%

### DIFF
--- a/agent/static/index.html
+++ b/agent/static/index.html
@@ -11,7 +11,7 @@
 </head>
 <body>
     <div class="header">
-        <img src="assets/gitiq-logo.svg" alt="GitIQ Logo" class="logo" style="width: 120px; height: 50px;">
+        <img src="assets/gitiq-logo.svg" alt="GitIQ Logo" class="logo" style="width: 180px; height: 75px;">
         <div id="repoStatus" class="repo-status">
             Checking repository status...
         </div>


### PR DESCRIPTION
## Prompt
Increase the size of the logo by 50%

## Summary of Changes
Updated the GitIQ logo dimensions in the main interface to improve visibility and brand presence by increasing both width and height measurements by 50% from their original values.

### Technical Details
- Modified logo width from 120px to 180px
- Modified logo height from 50px to 75px
- Maintained aspect ratio during size increase
- Changes applied to the main logo element in index.html

### Files Modified
- agent/static/index.html

Model: Claude 3.5 Sonnet (latest)